### PR TITLE
East/West Catalog checking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,18 @@ uv run ruff check --fix
 uv run ruff format
 ```
 
+### Tests
+```bash
+uv run pytest                          # everything, live network tests included
+uv run pytest -m "not live"            # offline only
+uv run pytest -m "live and not watch"  # live hard invariants only
+uv run pytest -m watch                 # "did the catalogs change?" checks
+```
+`live` tests hit real ESGF catalogs and run by default — a catalog we do not
+control moving under us is exactly what we want to hear about. `watch` tests
+assert an *observed* server state still holds; a failure means the world changed
+and a decision is due, not that our code broke. Markers in `pyproject.toml`.
+
 ### Docs (requires `uv sync --group docs` first)
 ```bash
 myst start          # local preview server at http://localhost:3000
@@ -36,7 +48,14 @@ jupyter kernelspec uninstall esgf-virtual-zarr
 
 ## Architecture
 
-This is a research project with no installable Python package — it contains scripts and notebooks demonstrating how to create virtual Zarr reference stores for CMIP6 data.
+A research project — scripts and notebooks demonstrating how to create virtual Zarr reference stores for CMIP6/CMIP7 data — plus an installable package, `src/cmip7_virtualization/`.
+
+**`catalog.py`** — the only module documented here; the rest arrive on their own branches.
+
+- `STAC_BASES`: read/write endpoints for test and production on both the East (CEDA) and West federations.
+- `collection_counts(base, verify=True)`: item count per collection. Absorbs two server quirks so callers need not know them — (a) `/collections` can 500 *wholesale* when a single collection document is unserialisable (West's `obs4ref`), so `_collections_meta` falls back to the root catalog's `child` links; (b) West advertises lowercase ids (`cmip6plus`) but stores canonical DRS case (`CMIP6Plus`) and `/search` is case-sensitive, so the collection title is OR'd in alongside `upper()`/`lower()`. ⚠️ `verify=True` reconciles against the unfiltered total and, on mismatch, **pages every item** — 391k on East prod. Pass `verify=False` on hot paths.
+- `is_reference_asset(asset)`: substring-matches `kerchunk`/`icechunk` in the media type and the `reference`/`virtual` roles, because publishers disagree on spelling (`application/vnd.zarr+kerchunk` vs our `application/vnd+zarr+kerchunk`).
+- `notebooks/catalog-discovery/catalog-check.ipynb` prints the whole matrix; `tests/test_live_catalogs.py` is the live monitor.
 
 **Two reference-generation patterns:**
 

--- a/README.md
+++ b/README.md
@@ -26,17 +26,6 @@ collection_counts("https://api.stac.esgf.ceda.ac.uk")
 East (CEDA) and West federations. `notebooks/catalog-discovery/catalog-check.ipynb`
 prints the full matrix in one go.
 
-Two server-side quirks are handled inside `collection_counts`, so callers do not
-have to know about them:
-
-- `/collections` can return **HTTP 500 as a whole** when a *single* collection
-  document fails to serialise — West integration's `obs4ref` does exactly this.
-  Discovery falls back to the root catalog's `child` links, which name each
-  collection separately.
-- West advertises lowercase collection ids (`cmip6plus`) but stores items under
-  the canonical DRS case (`CMIP6Plus`), and `/search` is **case-sensitive**. The
-  collection title is searched alongside the id, with a full-item tally as a
-  last-resort reconciliation.
 
 ### Running the tests
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,60 @@ uv sync
 ```
 
 
+## Catalog discovery and monitoring
+
+The ESGF STAC catalogs we build against are operated by other people and change
+without notice. `cmip7_virtualization.catalog` wraps them:
+
+```python
+from cmip7_virtualization.catalog import STAC_BASES, collection_counts
+
+collection_counts("https://api.stac.esgf.ceda.ac.uk")
+# {'CMIP6': 390739, 'CMIP6Plus': 0, 'CMIP7': 0, 'CORDEX-CMIP6': 990, 'obs4REF': 0}
+```
+
+`STAC_BASES` holds the read/write endpoints for test and production on both the
+East (CEDA) and West federations. `notebooks/catalog-discovery/catalog-check.ipynb`
+prints the full matrix in one go.
+
+Two server-side quirks are handled inside `collection_counts`, so callers do not
+have to know about them:
+
+- `/collections` can return **HTTP 500 as a whole** when a *single* collection
+  document fails to serialise — West integration's `obs4ref` does exactly this.
+  Discovery falls back to the root catalog's `child` links, which name each
+  collection separately.
+- West advertises lowercase collection ids (`cmip6plus`) but stores items under
+  the canonical DRS case (`CMIP6Plus`), and `/search` is **case-sensitive**. The
+  collection title is searched alongside the id, with a full-item tally as a
+  last-resort reconciliation.
+
+### Running the tests
+
+```bash
+uv run pytest                          # everything, including live network tests
+uv run pytest -m "not live"            # offline only — no network
+uv run pytest -m "live and not watch"  # live hard invariants only
+uv run pytest -m watch                 # "did the catalogs change?" checks
+```
+
+`tests/test_live_catalogs.py` hits the real catalogs. It is split by marker:
+
+- **`live`** — hard invariants. Every endpoint is a reachable STAC API, collection
+  discovery works, per-collection counts reconcile against the unfiltered total,
+  and the collections we depend on have not been emptied (floors sit ~10% below
+  observed, so ordinary publication never trips them).
+- **`watch`** — assertions that the catalogs are *still as last observed*. A
+  failure here is a signal, not a defect: it means something moved and a decision
+  is due. Currently watched: West integration's `/collections` 500, West's
+  collection-id case sensitivity, the fact that **no catalog serves virtual-Zarr
+  reference assets**, collections that are still empty (notably CMIP7 on East
+  prod), and the retired `integration-testing` West host.
+
+Each `watch` failure message says what to do about it. The most consequential are
+CMIP7 appearing on East prod and reference assets reappearing anywhere.
+
+
 ## license
 
 All the code in this repository is [MIT](https://choosealicense.com/licenses/mit/)-licensed, but we request that you please provide attribution if reusing any of our digital content (graphics, logo, articles, etc.).

--- a/notebooks/catalog-discovery/catalog-check.ipynb
+++ b/notebooks/catalog-discovery/catalog-check.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b1e6d55e",
+   "metadata": {},
+   "source": [
+    "# Search different catalogs\n",
+    "\n",
+    "Check number of CMIP7 and CMIP6 datasets on each catalog endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "991fd590",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T20:10:47.640726Z",
+     "iopub.status.busy": "2026-07-25T20:10:47.640643Z",
+     "iopub.status.idle": "2026-07-25T20:10:48.122506Z",
+     "shell.execute_reply": "2026-07-25T20:10:48.122173Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from cmip7_virtualization.catalog import STAC_BASES, collection_counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6f9a1144",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-25T20:10:48.123838Z",
+     "iopub.status.busy": "2026-07-25T20:10:48.123627Z",
+     "iopub.status.idle": "2026-07-25T20:10:54.106412Z",
+     "shell.execute_reply": "2026-07-25T20:10:54.104326Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[test/east] https://api.stac.esgf-test.ceda.ac.uk\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    CMIP6        29497\n",
+      "    CMIP6Test    0\n",
+      "    CMIP7        9\n",
+      "    CORDEX-CMIP6 19\n",
+      "    obs4MIPs     0\n",
+      "\n",
+      "[test/west] https://discovery.integration.esgf-west.org\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    cmip6        8565\n",
+      "    cmip6plus    10\n",
+      "    cmip7        6\n",
+      "    cordex-cmip6 6\n",
+      "    obs4ref      0\n",
+      "\n",
+      "[production/east] https://api.stac.esgf.ceda.ac.uk\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    CMIP6        390739\n",
+      "    CMIP6Plus    0\n",
+      "    CMIP7        0\n",
+      "    CORDEX-CMIP6 990\n",
+      "    obs4REF      0\n",
+      "\n",
+      "[production/west] https://discovery.production.esgf-west.org\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    cmip6        0\n",
+      "    cmip6plus    0\n",
+      "    cmip7        0\n",
+      "    cordex-cmip6 0\n",
+      "    obs4ref      0\n"
+     ]
+    }
+   ],
+   "source": [
+    "for env, sites in STAC_BASES.items():\n",
+    "    for site, endpoints in sites.items():\n",
+    "        for base in endpoints[\"read\"]:\n",
+    "            print(f\"\\n[{env}/{site}] {base}\")\n",
+    "            try:\n",
+    "                for cid, n in collection_counts(base).items():\n",
+    "                    print(f\"    {cid:12s} {n if n is not None else '?'}\")\n",
+    "            except Exception as e:\n",
+    "                print(f\"    ERROR: {type(e).__name__}: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4eb25098",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,7 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "live: hits a live remote catalog over the network (deselect with -m 'not live')",
+    "watch: asserts an observed catalog state still holds; a failure means the catalogs changed, not that our code broke (deselect with -m 'not watch')",
+]

--- a/src/cmip7_virtualization/catalog.py
+++ b/src/cmip7_virtualization/catalog.py
@@ -1,4 +1,53 @@
-from typing import Dict, List
+from collections import Counter
+from typing import Dict, Iterator, List, Optional, Tuple
+
+import httpx
+
+STAC_BASES = {
+    "test": {
+        "east": {
+            "read": ["https://api.stac.esgf-test.ceda.ac.uk"],
+            "write": ["https://api.stac.esgf-test.ceda.ac.uk"],
+        },
+        "west": {
+            # ``integration-testing.api.stac.esgf-west.org`` was retired (NXDOMAIN
+            # as of 2026-07-25); discovery.integration is now the populated one
+            # (~8.6k items) and is the only integration read endpoint.
+            "read": ["https://discovery.integration.esgf-west.org"],
+            "write": ["https://transaction.integration.esgf-west.org"],
+        },
+    },
+    "production": {
+        "east": {
+            "read": ["https://api.stac.esgf.ceda.ac.uk"],
+            "write": ["https://api.stac.esgf.ceda.ac.uk"],
+        },
+        "west": {
+            "read": ["https://discovery.production.esgf-west.org"],
+            "write": ["https://transaction.production.esgf-west.org"],
+        },
+    },
+}
+
+
+def is_reference_asset(asset: Dict) -> bool:
+    """True if a STAC asset is a virtual-Zarr reference rather than a data file.
+
+    Deliberately generous about spelling. ``references.MEDIA_TYPES`` writes
+    kerchunk as ``application/vnd+zarr+kerchunk`` while East test published
+    ``application/vnd.zarr+kerchunk``; we emit roles ``["virtual", "data"]`` while
+    other publishers use ``reference``. Substring-matching the engine name means a
+    punctuation disagreement cannot make a reference asset invisible — which
+    matters most for the live monitor in ``tests/test_live_catalogs.py``, whose
+    whole job is to notice the day a catalog starts serving these again.
+    """
+    media_type = (asset.get("type") or "").lower()
+    roles = {str(r).lower() for r in asset.get("roles") or []}
+    return (
+        "kerchunk" in media_type
+        or "icechunk" in media_type
+        or bool(roles & {"reference", "virtual"})
+    )
 
 
 def files_from_stac_item(stac_item: Dict) -> Dict[str, str]:
@@ -13,3 +62,103 @@ def files_from_stac_item(stac_item: Dict) -> Dict[str, str]:
 def urls_from_stac_item(stac_item: Dict) -> List[str]:
     """Return ordered list of NetCDF hrefs for a single STAC item."""
     return list(files_from_stac_item(stac_item).values())
+
+
+def _iter_all_items(base: str, page_size: int = 250) -> Iterator[Dict]:
+    """Yield every item from a STAC ``/search``, following ``next`` links."""
+    url, method, body = f"{base}/search", "POST", {"limit": page_size}
+    while True:
+        r = (
+            httpx.post(url, json=body, timeout=120)
+            if method == "POST"
+            else httpx.get(url, timeout=120)
+        ).json()
+        features = r.get("features", [])
+        yield from features
+        nxt = next(
+            (link for link in r.get("links", []) if link.get("rel") == "next"), None
+        )
+        if not nxt or not features:
+            break
+        url, method = nxt["href"], (nxt.get("method") or "GET").upper()
+        if method == "POST":
+            body = (
+                {**body, **nxt.get("body", {})}
+                if nxt.get("merge")
+                else nxt.get("body", {})
+            )
+
+
+def _collections_meta(base: str) -> List[Tuple[str, str]]:
+    """Return ``[(collection_id, title)]`` for a STAC base URL.
+
+    Prefers ``/collections``. That endpoint serialises *every* collection document
+    in one response, so a single malformed document takes the whole listing down
+    with a 500 (integration West does exactly this: ``/collections/obs4ref`` 500s,
+    which 500s ``/collections``). Fall back to the root catalog's ``child`` links,
+    which name each collection individually and so survive one bad document.
+
+    ``title`` may be empty (East test publishes ``""``); on West it carries the
+    canonical DRS casing (``CMIP6Plus``) that the lowercase id (``cmip6plus``)
+    loses, which matters because ``/search`` is case-sensitive on collection ids.
+    """
+    try:
+        r = httpx.get(f"{base}/collections", timeout=30)
+        r.raise_for_status()
+        return [(c["id"], c.get("title") or "") for c in r.json()["collections"]]
+    except (httpx.HTTPError, KeyError, ValueError):
+        root = httpx.get(f"{base}/", timeout=30)
+        root.raise_for_status()
+        return [
+            (link["href"].rstrip("/").rsplit("/", 1)[-1], link.get("title") or "")
+            for link in root.json().get("links", [])
+            if link.get("rel") == "child"
+        ]
+
+
+def _search_count(base: str, collections: Optional[List[str]] = None) -> Optional[int]:
+    """Total items matching a STAC ``/search`` (None if the server won't report it)."""
+    body: Dict = {"limit": 1}
+    if collections is not None:
+        body["collections"] = collections
+    r = httpx.post(f"{base}/search", json=body, timeout=60).json()
+    return next(
+        (r[k] for k in ("numMatched", "numberMatched") if r.get(k) is not None),
+        (r.get("context") or {}).get("matched"),
+    )
+
+
+def collection_counts(base: str, verify: bool = True) -> Dict[str, Optional[int]]:
+    """Item count for every collection exposed by a STAC base URL.
+
+    Returns {collection_id: count}, keyed by the id from ``/collections``. count
+    is None if the server doesn't report a match total.
+
+    West advertises collection ids as esgvoc project names in lowercase (``cmip6``,
+    ``cmip6plus``) but publishes items under the canonical DRS case (``CMIP6``,
+    ``CMIP6Plus``), and ``/search`` is case-sensitive. ``CMIP6Plus`` is *not* the
+    upper- or lower-case of ``cmip6plus``, so we OR the collection *title* (which
+    carries the canonical casing) in with ``[cid, cid.upper(), cid.lower()]``.
+
+    With ``verify`` True (default) we reconcile the per-collection sum against the
+    unfiltered total; if they disagree (or the server won't report totals), we page
+    through every item once and tally by each item's real ``collection`` field. That
+    is robust to any canonical casing, not just upper/lower/title.
+    """
+    available = _collections_meta(base)
+
+    counts: Dict[str, Optional[int]] = {}
+    for cid, title in available:
+        candidates = dict.fromkeys([cid, title, cid.upper(), cid.lower()])
+        counts[cid] = _search_count(base, [c for c in candidates if c])
+
+    if verify:
+        total = _search_count(base)
+        got = sum(v for v in counts.values() if v)
+        if total is None or got != total:
+            tally = Counter(
+                (f.get("collection") or "").lower() for f in _iter_all_items(base)
+            )
+            counts = {cid: tally.get(cid.lower(), 0) for cid, _ in available}
+
+    return counts

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,145 @@
+"""Tests for collection discovery in :mod:`cmip7_virtualization.catalog`.
+
+Offline: ``httpx.get`` is monkeypatched, so these encode the two catalog shapes we
+actually observed rather than hitting the live ESGF STAC APIs.
+"""
+
+import httpx
+import pytest
+
+from cmip7_virtualization import catalog
+
+BASE = "https://example.test"
+
+# East: /collections works, ids already canonical, titles empty.
+EAST_COLLECTIONS = {
+    "collections": [{"id": "CMIP6", "title": ""}, {"id": "CMIP6Test", "title": ""}]
+}
+
+# West: lowercase ids, canonical DRS casing only in the title.
+WEST_COLLECTIONS = {
+    "collections": [
+        {"id": "cmip6", "title": "CMIP6"},
+        {"id": "cmip6plus", "title": "CMIP6Plus"},
+    ]
+}
+WEST_ROOT = {
+    "links": [
+        {"rel": "self", "href": f"{BASE}/"},
+        {"rel": "data", "href": f"{BASE}/collections"},
+        {"rel": "child", "title": "CMIP6", "href": f"{BASE}/collections/cmip6"},
+        {"rel": "child", "title": "CMIP6Plus", "href": f"{BASE}/collections/cmip6plus"},
+        {"rel": "child", "title": "obs4REF", "href": f"{BASE}/collections/obs4ref"},
+    ]
+}
+
+
+def _fake_get(routes):
+    """Build an ``httpx.get`` stub serving ``{path: (status, json)}``."""
+
+    def get(url, **kwargs):
+        status, payload = routes[url[len(BASE) :]]
+        request = httpx.Request("GET", url)
+        return httpx.Response(status, json=payload, request=request)
+
+    return get
+
+
+def test_collections_meta_prefers_collections_endpoint(monkeypatch):
+    monkeypatch.setattr(
+        httpx, "get", _fake_get({"/collections": (200, WEST_COLLECTIONS)})
+    )
+    assert catalog._collections_meta(BASE) == [
+        ("cmip6", "CMIP6"),
+        ("cmip6plus", "CMIP6Plus"),
+    ]
+
+
+def test_collections_meta_tolerates_empty_titles(monkeypatch):
+    monkeypatch.setattr(
+        httpx, "get", _fake_get({"/collections": (200, EAST_COLLECTIONS)})
+    )
+    assert catalog._collections_meta(BASE) == [("CMIP6", ""), ("CMIP6Test", "")]
+
+
+def test_collections_meta_falls_back_to_root_children_on_500(monkeypatch):
+    """One malformed collection doc 500s the whole listing; root children survive it."""
+    monkeypatch.setattr(
+        httpx,
+        "get",
+        _fake_get({"/collections": (500, None), "/": (200, WEST_ROOT)}),
+    )
+    assert catalog._collections_meta(BASE) == [
+        ("cmip6", "CMIP6"),
+        ("cmip6plus", "CMIP6Plus"),
+        ("obs4ref", "obs4REF"),
+    ]
+
+
+def test_collections_meta_raises_when_root_also_fails(monkeypatch):
+    monkeypatch.setattr(
+        httpx, "get", _fake_get({"/collections": (500, None), "/": (503, None)})
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        catalog._collections_meta(BASE)
+
+
+def test_collection_counts_ors_title_casing_into_search(monkeypatch):
+    """``/search`` is case-sensitive, so the canonical title must be a candidate."""
+    monkeypatch.setattr(
+        httpx, "get", _fake_get({"/collections": (200, WEST_COLLECTIONS)})
+    )
+    seen = {}
+
+    def fake_post(url, json, **kwargs):
+        cols = json.get("collections")
+        if cols is None:  # unfiltered total, used by verify
+            return httpx.Response(
+                200, json={"numMatched": 12}, request=httpx.Request("POST", url)
+            )
+        seen[cols[0]] = cols
+        n = 10 if "CMIP6Plus" in cols else 2
+        return httpx.Response(
+            200, json={"numMatched": n}, request=httpx.Request("POST", url)
+        )
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    assert catalog.collection_counts(BASE) == {"cmip6": 2, "cmip6plus": 10}
+    # CMIP6Plus is neither the upper- nor the lower-case of cmip6plus.
+    assert seen["cmip6plus"] == ["cmip6plus", "CMIP6Plus", "CMIP6PLUS"]
+    assert "" not in seen["cmip6"]  # empty titles never reach the request body
+
+
+# ``is_reference_asset`` backs the live monitor's "has any catalog started serving
+# references again?" test. A predicate that silently never matches would let that
+# monitor pass forever, so pin both the hits and the misses here, offline.
+
+REFERENCE_ASSETS = [
+    # What we emit (references.MEDIA_TYPES + roles).
+    {"type": "application/vnd.zarr+icechunk", "roles": ["virtual", "data"]},
+    # The kerchunk spelling in references.MEDIA_TYPES ...
+    {"type": "application/vnd+zarr+kerchunk", "roles": ["virtual", "data"]},
+    # ... versus the one East test actually published until 2026-06.
+    {"type": "application/vnd.zarr+kerchunk", "roles": ["data"]},
+    # Role alone, media type unhelpful.
+    {"type": "application/json", "roles": ["reference"]},
+    {"type": "APPLICATION/VND.ZARR+ICECHUNK", "roles": []},
+]
+
+DATA_ASSETS = [
+    {"type": "application/netcdf", "roles": ["data"]},
+    {"type": "text/html", "roles": ["data"]},
+    {"type": "application/netcdf"},  # no roles key at all
+    {},  # empty asset
+]
+
+
+@pytest.mark.parametrize("asset", REFERENCE_ASSETS)
+def test_is_reference_asset_detects_every_observed_spelling(asset):
+    assert catalog.is_reference_asset(asset)
+
+
+@pytest.mark.parametrize("asset", DATA_ASSETS)
+def test_is_reference_asset_ignores_plain_data_assets(asset):
+    assert not catalog.is_reference_asset(asset)

--- a/tests/test_live_catalogs.py
+++ b/tests/test_live_catalogs.py
@@ -1,0 +1,233 @@
+"""Live monitoring tests against the ESGF STAC catalogs in ``STAC_BASES``.
+
+These hit the network on purpose. We do not control any of these catalogs, and
+every one of them has already moved under us at least once: East prod went from
+empty to 391k items, East test lost its kerchunk assets, West's
+``integration-testing`` host vanished, West integration's ``/collections`` started
+returning 500. A fixture-backed unit test cannot see any of that. Those live in
+``test_catalog.py`` and cover the parsing logic; this module covers reality.
+
+Two markers, both applied to this file:
+
+``live``
+    Hits the network. ``uv run pytest -m "not live"`` skips the whole module.
+
+``watch``
+    Asserts that a *currently observed* server-side state still holds. A failure
+    is not necessarily bad news — it means the catalogs changed and something
+    here needs a decision (drop a workaround, re-point a notebook, celebrate).
+    Run only the hard invariants with ``-m "live and not watch"``.
+
+Every count is a floor, not an equality: catalogs grow, and a test that fails on
+publication is a test people learn to ignore. Floors sit ~10% below the values
+observed on 2026-07-25, so they catch a catalog being wiped or a collection
+filter silently returning nothing, which is the failure that actually bites us.
+"""
+
+import httpx
+import pytest
+
+from cmip7_virtualization.catalog import (
+    STAC_BASES,
+    _search_count,
+    collection_counts,
+    is_reference_asset,
+)
+
+pytestmark = pytest.mark.live
+
+EAST_PROD = "https://api.stac.esgf.ceda.ac.uk"
+EAST_TEST = "https://api.stac.esgf-test.ceda.ac.uk"
+WEST_INTEGRATION = "https://discovery.integration.esgf-west.org"
+WEST_PROD = "https://discovery.production.esgf-west.org"
+
+READ_BASES = [
+    base
+    for sites in STAC_BASES.values()
+    for endpoints in sites.values()
+    for base in endpoints["read"]
+]
+
+# Floors, ~10% under the 2026-07-25 probe. Collections observed at 0 are asserted
+# as exactly 0 by the watch tests below instead, because "0 -> non-zero" is the
+# interesting event for those, not a regression.
+MIN_COUNTS = {
+    EAST_PROD: {"CMIP6": 350_000, "CORDEX-CMIP6": 890},
+    EAST_TEST: {"CMIP6": 26_500, "CMIP7": 8, "CORDEX-CMIP6": 17},
+    WEST_INTEGRATION: {"cmip6": 7_700, "cmip6plus": 9, "cmip7": 5, "cordex-cmip6": 5},
+    WEST_PROD: {},
+}
+
+# Collections observed empty on 2026-07-25. CMIP7 on East prod is the one this
+# project is actually waiting for.
+OBSERVED_EMPTY = {
+    EAST_PROD: ["CMIP6Plus", "CMIP7", "obs4REF"],
+    EAST_TEST: ["CMIP6Test", "obs4MIPs"],
+    WEST_INTEGRATION: ["obs4ref"],
+    WEST_PROD: ["cmip6", "cmip6plus", "cmip7", "cordex-cmip6", "obs4ref"],
+}
+
+
+def _sample_assets(base, limit=200):
+    """Return every asset dict from the first ``limit`` items of ``/search``."""
+    r = httpx.post(f"{base}/search", json={"limit": limit}, timeout=120)
+    r.raise_for_status()
+    return [
+        a
+        for f in r.json().get("features", [])
+        for a in (f.get("assets") or {}).values()
+    ]
+
+
+# --------------------------------------------------------------------------
+# Hard invariants — these must hold for any of our tooling to work at all.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("base", READ_BASES)
+def test_base_is_a_reachable_stac_api(base):
+    """Root document resolves and self-identifies as a STAC catalog."""
+    r = httpx.get(f"{base}/", timeout=60)
+    r.raise_for_status()
+    root = r.json()
+    assert root.get("type") == "Catalog", f"{base} root is not a STAC Catalog"
+    assert any("api.stacspec.org" in c for c in root.get("conformsTo", [])), (
+        f"{base} advertises no STAC conformance classes"
+    )
+
+
+@pytest.mark.parametrize("base", READ_BASES)
+def test_collection_discovery_survives_a_broken_collections_endpoint(base):
+    """``collection_counts`` returns collections for every base.
+
+    This is the regression guard for the West ``/collections`` 500: if the root
+    ``child``-link fallback in ``_collections_meta`` ever breaks, this fails here
+    rather than silently in a notebook.
+
+    ``verify=False`` on purpose. The reconciliation path pages every item in the
+    catalog, which on East prod means 391k items — fine as a one-off diagnostic,
+    not something to fire on every test run. The reconciliation itself is asserted
+    separately below, cheaply.
+    """
+    counts = collection_counts(base, verify=False)
+    assert counts, f"{base} exposed no collections at all"
+    assert all(isinstance(n, int) for n in counts.values()), (
+        f"{base} did not report match totals: {counts}"
+    )
+
+
+@pytest.mark.parametrize("base", READ_BASES)
+def test_per_collection_counts_reconcile_with_the_unfiltered_total(base):
+    """Per-collection sum must equal the unfiltered ``/search`` total.
+
+    A shortfall means at least one collection id is being filtered with the wrong
+    casing — the West ``cmip6plus`` vs ``CMIP6Plus`` bug — and those items are
+    invisible to anything that filters by collection.
+    """
+    counts = collection_counts(base, verify=False)
+    total = _search_count(base)
+    assert total is not None, f"{base} would not report a match total"
+    assert sum(counts.values()) == total, (
+        f"{base}: collections sum to {sum(counts.values())} but /search reports "
+        f"{total}; a collection id is likely being filtered with the wrong case. "
+        f"Got {counts}"
+    )
+
+
+@pytest.mark.parametrize("base,floors", MIN_COUNTS.items())
+def test_populated_collections_have_not_been_emptied(base, floors):
+    """Collections we depend on still hold roughly what they held on 2026-07-25."""
+    counts = collection_counts(base, verify=False)
+    for cid, floor in floors.items():
+        assert cid in counts, f"{base} no longer exposes collection {cid!r}"
+        assert counts[cid] >= floor, (
+            f"{base} {cid}: {counts[cid]} items, below the floor of {floor}. "
+            f"The catalog was wiped, re-indexed, or the collection was renamed."
+        )
+
+
+# --------------------------------------------------------------------------
+# Watch tests — assert the world is still as we last observed it. Failing means
+# something changed and a decision is due, not that our code is broken.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.watch
+def test_west_integration_collections_endpoint_still_returns_500():
+    """``/collections`` on West integration is broken by one bad document.
+
+    Every other collection serialises; ``/collections/obs4ref`` alone 500s, and
+    that takes the whole listing down with it. If this test fails, upstream fixed
+    it — retire the root-``child``-link fallback in ``_collections_meta`` and
+    close the report against ``esgf2-us/west-discovery``.
+    """
+    listing = httpx.get(f"{WEST_INTEGRATION}/collections", timeout=60)
+    obs4ref = httpx.get(f"{WEST_INTEGRATION}/collections/obs4ref", timeout=60)
+
+    assert listing.status_code == 500, (
+        f"/collections now returns {listing.status_code} — upstream may have fixed it"
+    )
+    assert obs4ref.status_code == 500, (
+        f"/collections/obs4ref now returns {obs4ref.status_code} — the blamed "
+        f"document is fine, so the 500 has a different cause now"
+    )
+
+
+@pytest.mark.watch
+def test_west_search_is_still_case_sensitive_on_collection_ids():
+    """West advertises ``cmip6`` but stores ``CMIP6``, and ``/search`` cares.
+
+    If this fails, the casing was reconciled upstream and the title/upper/lower
+    fan-out in ``collection_counts`` can collapse to the advertised id.
+    """
+    assert _search_count(WEST_INTEGRATION, ["CMIP6"]) > 0, (
+        "canonical casing found nothing"
+    )
+    assert _search_count(WEST_INTEGRATION, ["cmip6"]) == 0, (
+        "lowercase collection id now matches items — casing may be fixed upstream"
+    )
+
+
+@pytest.mark.watch
+@pytest.mark.parametrize("base", [EAST_PROD, EAST_TEST, WEST_INTEGRATION])
+def test_no_catalog_serves_reference_assets_yet(base):
+    """The premise of this whole project: nobody publishes virtual refs today.
+
+    East test carried 19,105 kerchunk ``reference_file`` assets on 2026-06-09 and
+    has none now. When this fails, a catalog started serving references again —
+    that is the event Track 3 has been waiting for, so go look at what it emits.
+    """
+    assets = _sample_assets(base)
+    assert assets, f"{base} returned no assets to inspect"
+    found = [a for a in assets if is_reference_asset(a)]
+    assert not found, (
+        f"{base} now serves {len(found)} reference asset(s), e.g. {found[0]}"
+    )
+
+
+@pytest.mark.watch
+@pytest.mark.parametrize("base", list(OBSERVED_EMPTY))
+def test_collections_observed_empty_are_still_empty(base):
+    """Notably: CMIP7 on East prod, and all of West production.
+
+    CMIP7 arriving on East prod is the single most useful thing that could happen
+    to this project, so it is worth a loud test rather than a quiet notebook run.
+    """
+    counts = collection_counts(base, verify=False)
+    non_empty = {
+        cid: counts.get(cid) for cid in OBSERVED_EMPTY[base] if counts.get(cid)
+    }
+    assert not non_empty, (
+        f"{base} now has items in previously empty collections: {non_empty}"
+    )
+
+
+@pytest.mark.watch
+def test_retired_west_host_is_still_gone():
+    """``integration-testing.api.stac.esgf-west.org`` was NXDOMAIN on 2026-07-25.
+
+    It was removed from ``STAC_BASES``. If DNS resolves again, reconsider — it
+    used to be the best-populated West endpoint.
+    """
+    with pytest.raises(httpx.ConnectError):
+        httpx.get("https://integration-testing.api.stac.esgf-west.org/", timeout=30)


### PR DESCRIPTION
This PR adds a bit of logic to document the various read/write stac endpoints used by ESGF East and West and adds a notebook and test (same logic) to check the status of each of these catalogs (they have been changing frequently). 