### PR TITLE
Add unit tests for the reference asset model and selection policy

### DIFF
--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,0 +1,118 @@
+"""Unit tests for the reference asset model + selection policy."""
+
+import pytest
+
+from cmip7_virtualization.references import (
+    MEDIA_TYPES,
+    build_reference_asset,
+    is_reference_asset,
+    reference_asset_key,
+    select_reference,
+)
+
+
+def test_asset_key():
+    assert reference_asset_key("icechunk", "s3") == "reference_icechunk_s3"
+    assert reference_asset_key("kerchunk", "osn") == "reference_kerchunk_osn"
+
+
+def test_build_asset_icechunk_s3():
+    a = build_reference_asset(
+        "icechunk",
+        "s3",
+        "s3://bucket/key/",
+        source_node="esgf-world",
+        region="us-east-1",
+        anonymous=True,
+    )
+    assert a["type"] == MEDIA_TYPES["icechunk"] == "application/vnd.zarr+icechunk"
+    assert a["roles"] == ["virtual", "data"]
+    assert a["cmip7:engine"] == "icechunk"
+    assert a["cmip7:storage"] == "s3"
+    assert a["cmip7:source_node"] == "esgf-world"
+    assert a["xarray:storage_options"] == {"region": "us-east-1", "anonymous": True}
+
+
+def test_build_asset_unknown_engine():
+    with pytest.raises(ValueError):
+        build_reference_asset("zarr", "s3", "s3://b/k", source_node="x")
+
+
+def test_build_asset_no_storage_options_when_unset():
+    a = build_reference_asset("icechunk", "osn", "https://osn/x", source_node="ceda")
+    assert "xarray:storage_options" not in a
+
+
+def _assets():
+    return {
+        "data0000": {
+            "href": "https://dap.ceda.ac.uk/a.nc",
+            "type": "application/netcdf",
+            "roles": ["data"],
+        },
+        "reference_file": build_reference_asset(
+            "kerchunk", "http", "https://dap.ceda.ac.uk/a.json", source_node="ceda"
+        ),
+        "reference_icechunk_osn": build_reference_asset(
+            "icechunk", "osn", "https://nyu1.osn.mghpcc.org/b/k", source_node="ceda"
+        ),
+        "reference_icechunk_s3": build_reference_asset(
+            "icechunk", "s3", "s3://bucket/k", source_node="ceda"
+        ),
+    }
+
+
+def test_is_reference_asset():
+    a = _assets()
+    assert not is_reference_asset(a["data0000"])
+    assert is_reference_asset(a["reference_file"])
+    assert is_reference_asset(a["reference_icechunk_s3"])
+
+
+def test_select_prefers_icechunk_then_s3():
+    key, _ = select_reference(_assets())
+    assert key == "reference_icechunk_s3"
+
+
+def test_select_prefers_osn_when_s3_absent():
+    a = _assets()
+    del a["reference_icechunk_s3"]
+    key, _ = select_reference(a)
+    assert key == "reference_icechunk_osn"
+
+
+def test_select_storage_preference_override():
+    key, _ = select_reference(_assets(), prefer_storage=("osn", "s3", "http"))
+    assert key == "reference_icechunk_osn"
+
+
+def test_select_engine_preference_override():
+    # prefer kerchunk -> the CEDA reference_file wins despite icechunk options
+    key, _ = select_reference(_assets(), prefer_engine=("kerchunk", "icechunk"))
+    assert key == "reference_file"
+
+
+def test_select_ignores_data_assets():
+    only_data = {
+        "data0000": {"href": "x.nc", "type": "application/netcdf", "roles": ["data"]}
+    }
+    with pytest.raises(ValueError):
+        select_reference(only_data)
+
+
+def test_select_classifies_by_media_type_without_props():
+    # assets lacking cmip7:* props still classify via media_type + href
+    assets = {
+        "k": {
+            "href": "https://dap.ceda.ac.uk/a.json",
+            "type": MEDIA_TYPES["kerchunk"],
+            "roles": ["virtual"],
+        },
+        "i": {
+            "href": "s3://bucket/k",
+            "type": MEDIA_TYPES["icechunk"],
+            "roles": ["virtual"],
+        },
+    }
+    key, _ = select_reference(assets)
+    assert key == "i"


### PR DESCRIPTION
`references.py` landed on `main` in #26/#29 without tests. This adds them — nothing else, no source changes.

## What's covered

**`build_reference_asset()`**
- emits the expected media type, `roles`, `cmip7:*` properties and `xarray:storage_options`
- omits `xarray:storage_options` entirely when no options are set, rather than emitting an empty dict
- raises on an unknown engine

**`select_reference()`**
- honours the default ordering (icechunk > kerchunk, s3 > osn)
- respects both `prefer_engine` and `prefer_storage` overrides
- ignores plain data assets, and raises when there is no reference at all
- **classifies assets that carry no `cmip7:*` properties by media type alone**

That last one is the case that actually matters against third-party catalogs: nobody outside this repo writes our extension fields, so selection has to work off `type` + `href`. It is the easiest behaviour to regress and the hardest to notice from a notebook.

## Notes

- Offline, no network, no fixtures. 11 tests, ~0.3s.
- Passes against `main` unmodified — this is a pure test-coverage addition, so it should go green without touching anything else.
- `ruff check` and `ruff format` clean.

Split out of the `track-c-esgadd-west-catalog` branch, which is being broken into reviewable units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)