### PR TITLE
Ignore internal/ and *.nc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,9 @@ combined_full.json
 notebooks/temp_test/
 # git worktrees (see CLAUDE.md "Worktree workflow")
 .worktrees/
+
+# internal planning notes, todos, and session scratch — not for the public repo
+internal/
+
+# NetCDF source data — inputs to reference generation, never committed
+*.nc


### PR DESCRIPTION
Adds two `.gitignore` rules for things that routinely sit in a working checkout but must never be committed.

- **`internal/`** — planning notes, todos, and session scratch. Local-only by design; the public repo should not carry it.
- **`*.nc`** — NetCDF source data. Reference generation downloads inputs into the tree (currently ~1.5 GB under `notebooks/reference-generation/data/`), so a stray `git add -A` would stage all of it.

Neither pattern matches anything currently tracked (`git ls-files | grep '\.nc$'` is empty), so no existing file changes status.

Verified:

```
$ git check-ignore -v internal/handoff.md notebooks/reference-generation/data/thetao_*.nc
.gitignore:171:internal/   internal/handoff.md
.gitignore:174:*.nc        notebooks/reference-generation/data/thetao_*.nc
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)